### PR TITLE
Unwrap textLabel to access text property

### DIFF
--- a/SplitViewControllerDemo/SelectColorTableViewController.swift
+++ b/SplitViewControllerDemo/SelectColorTableViewController.swift
@@ -62,7 +62,7 @@ class SelectColorTableViewController: UITableViewController, UISplitViewControll
         let cell = tableView.dequeueReusableCellWithIdentifier(colorCellIdentifier) as UITableViewCell
         
         let color = colors[indexPath.row]
-        cell.textLabel.text = color.displayName
+        cell.textLabel?.text = color.displayName
         
         return cell
     }


### PR DESCRIPTION
@NatashaTheRobot 

Hello Natasha,

I pulled your code down and found I needed to unwrap textLabel to access the text property. I've tested this code against Xcode 6.1.1.

Let me know if I made any mistakes, this is my first public pull request!

Jeff K.